### PR TITLE
FreeBSD build fixes

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -40,7 +40,7 @@ plugins: libs
 	$(MAKE) all -C plugins/wolf-shaper
 
 gen: plugins dpf/utils/lv2_ttl_generator
-	bash "$(CURDIR)/dpf/utils/generate-ttl.sh"
+	"$(CURDIR)/dpf/utils/generate-ttl.sh"
 ifeq ($(MACOS),true)
 	"$(CURDIR)/dpf/utils/generate-vst-bundles.sh"
 endif

--- a/Makefile
+++ b/Makefile
@@ -40,7 +40,7 @@ plugins: libs
 	$(MAKE) all -C plugins/wolf-shaper
 
 gen: plugins dpf/utils/lv2_ttl_generator
-	"$(CURDIR)/dpf/utils/generate-ttl.sh"
+	bash "$(CURDIR)/dpf/utils/generate-ttl.sh"
 ifeq ($(MACOS),true)
 	"$(CURDIR)/dpf/utils/generate-vst-bundles.sh"
 endif

--- a/Makefile
+++ b/Makefile
@@ -33,7 +33,7 @@ ifeq (,$(wildcard dpf/dgl))
 endif
 
 ifeq ($(HAVE_DGL),true)
-	$(MAKE) -C dpf/dgl
+	$(MAKE) -C dpf/dgl DGL_FLAGS="$(DGL_FLAGS) -DDGL_FILE_BROWSER_DISABLED"
 endif
 
 plugins: libs

--- a/plugins/Makefile.mk
+++ b/plugins/Makefile.mk
@@ -18,7 +18,12 @@ endif
 TARGET_DIR = ../../bin
 
 BUILD_C_FLAGS   += -I.
-BUILD_CXX_FLAGS += -I. -I../../dpf/distrho -I../../dpf/dgl -I./Common/Structures -I./Common/Widgets -I./Common/Utils -I./Resources -I./Config -I./Libs/inih -I./Libs/DSPFilters/include $(shell pkg-config --cflags gl)
+BUILD_CXX_FLAGS += -I. -I../../dpf/distrho -I../../dpf/dgl -I./Common/Structures -I./Common/Widgets -I./Common/Utils -I./Resources -I./Config -I./Libs/inih -I./Libs/DSPFilters/include
+
+# Fix missing GL/gl.h include on FreeBSD
+GL_INCLUDES = $(shell pkg-config --cflags-only-I gl)
+BUILD_C_FLAGS += $(GL_INCLUDES)
+BUILD_CXX_FLAGS += $(GL_INCLUDES)
 
 ifeq ($(HAVE_DGL),true)
 BASE_FLAGS += -DHAVE_DGL -DDGL_FILE_BROWSER_DISABLED

--- a/plugins/Makefile.mk
+++ b/plugins/Makefile.mk
@@ -18,7 +18,7 @@ endif
 TARGET_DIR = ../../bin
 
 BUILD_C_FLAGS   += -I.
-BUILD_CXX_FLAGS += -I. -I../../dpf/distrho -I../../dpf/dgl -I./Common/Structures -I./Common/Widgets -I./Common/Utils -I./Resources -I./Config -I./Libs/inih -I./Libs/DSPFilters/include
+BUILD_CXX_FLAGS += -I. -I../../dpf/distrho -I../../dpf/dgl -I./Common/Structures -I./Common/Widgets -I./Common/Utils -I./Resources -I./Config -I./Libs/inih -I./Libs/DSPFilters/include $(shell pkg-config --cflags gl)
 
 ifeq ($(HAVE_DGL),true)
 BASE_FLAGS += -DHAVE_DGL -DDGL_FILE_BROWSER_DISABLED

--- a/plugins/Makefile.mk
+++ b/plugins/Makefile.mk
@@ -21,7 +21,7 @@ BUILD_C_FLAGS   += -I.
 BUILD_CXX_FLAGS += -I. -I../../dpf/distrho -I../../dpf/dgl -I./Common/Structures -I./Common/Widgets -I./Common/Utils -I./Resources -I./Config -I./Libs/inih -I./Libs/DSPFilters/include
 
 ifeq ($(HAVE_DGL),true)
-BASE_FLAGS += -DHAVE_DGL
+BASE_FLAGS += -DHAVE_DGL -DDGL_FILE_BROWSER_DISABLED
 endif
 
 ifeq ($(HAVE_JACK),true)


### PR DESCRIPTION
- Disable DGL's file browser. This plugin does not need it, and it would make the build fail because of mntent.h (which does not appear to exist on FreeBSD)
- Fix missing GL include while building Wolf Common:
```
In file included from Common/Utils/src/Mathf.cpp:1:
In file included from ../../dpf/dgl/Geometry.hpp:20:
../../dpf/dgl/Base.hpp:82:11: fatal error: 'GL/gl.h' file not found
```
- The build would fail because of this shebang: https://github.com/wolf-plugins/DPF/blob/e5fb1bc2f4f49937fb7585052d4a74b1e427327d/utils/generate-ttl.sh#L1. I changed the shebang to `/usr/bin/env bash`, which should be more portable.