### PR TITLE
Fix dsp/gui inconsistencies and improve generic UI

### DIFF
--- a/src/WolfShaperPlugin.cpp
+++ b/src/WolfShaperPlugin.cpp
@@ -89,7 +89,7 @@ protected:
             parameter.ranges.min = 0.0f;
             parameter.ranges.max = 2.0f;
             parameter.ranges.def = 1.0f;
-            parameter.hints = kParameterIsAutomatable | kParameterIsLogarithmic;
+            parameter.hints = kParameterIsAutomatable;
             break;
         case paramWet:
             parameter.name = "Wet";
@@ -105,7 +105,7 @@ protected:
             parameter.ranges.min = 0.0f;
             parameter.ranges.max = 1.0f;
             parameter.ranges.def = 1.0f;
-            parameter.hints = kParameterIsAutomatable | kParameterIsLogarithmic;
+            parameter.hints = kParameterIsAutomatable;
             break;
         case paramRemoveDC:
             parameter.name = "Remove DC Offset";

--- a/src/WolfShaperPlugin.cpp
+++ b/src/WolfShaperPlugin.cpp
@@ -123,6 +123,22 @@ protected:
             parameter.ranges.max = 4.0f;
             parameter.ranges.def = 0.0f;
             parameter.hints = kParameterIsAutomatable | kParameterIsInteger;
+            parameter.enumValues.count = 5;
+            parameter.enumValues.restrictedMode = true;
+            {
+                ParameterEnumerationValue* const values = new ParameterEnumerationValue[5];
+                parameter.enumValues.values = values;
+                values[0].label = "None";
+                values[0].value = 0.f;
+                values[1].label = "2x";
+                values[1].value = 1.f;
+                values[2].label = "4x";
+                values[2].value = 2.f;
+                values[3].label = "8x";
+                values[3].value = 3.f;
+                values[4].label = "16x";
+                values[4].value = 4.f;
+            }
             break;
         case paramBipolarMode:
             parameter.name = "Bipolar Mode";
@@ -131,6 +147,16 @@ protected:
             parameter.ranges.max = 1.0f;
             parameter.ranges.def = 0.0f;
             parameter.hints = kParameterIsAutomatable | kParameterIsBoolean | kParameterIsInteger;
+            parameter.enumValues.count = 2;
+            parameter.enumValues.restrictedMode = true;
+            {
+                ParameterEnumerationValue* const values = new ParameterEnumerationValue[2];
+                parameter.enumValues.values = values;
+                values[0].label = "Unipolar";
+                values[0].value = 0.f;
+                values[1].label = "Bipolar";
+                values[1].value = 1.f;
+            }
             break;
         case paramHorizontalWarpType:
             //None, Bend +, Bend -, Bend +/-, Skew +, Skew -, Skew +/-
@@ -140,6 +166,26 @@ protected:
             parameter.ranges.max = 6.0f;
             parameter.ranges.def = 0.0f;
             parameter.hints = kParameterIsAutomatable | kParameterIsInteger;
+            parameter.enumValues.count = 7;
+            parameter.enumValues.restrictedMode = true;
+            {
+                ParameterEnumerationValue* const values = new ParameterEnumerationValue[7];
+                parameter.enumValues.values = values;
+                values[0].label = "None";
+                values[0].value = 0.f;
+                values[1].label = "Bend +";
+                values[1].value = 1.f;
+                values[2].label = "Bend -";
+                values[2].value = 2.f;
+                values[3].label = "Bend +/-";
+                values[3].value = 3.f;
+                values[4].label = "Skew +";
+                values[4].value = 4.f;
+                values[5].label = "Skew -";
+                values[5].value = 5.f;
+                values[6].label = "Skew +/-";
+                values[6].value = 6.f;
+            }
             break;
         case paramHorizontalWarpAmount:
             parameter.name = "H Warp Amount";
@@ -157,6 +203,26 @@ protected:
             parameter.ranges.max = 6.0f;
             parameter.ranges.def = 0.0f;
             parameter.hints = kParameterIsAutomatable | kParameterIsInteger;
+            parameter.enumValues.count = 7;
+            parameter.enumValues.restrictedMode = true;
+            {
+                ParameterEnumerationValue* const values = new ParameterEnumerationValue[7];
+                parameter.enumValues.values = values;
+                values[0].label = "None";
+                values[0].value = 0.f;
+                values[1].label = "Bend +";
+                values[1].value = 1.f;
+                values[2].label = "Bend -";
+                values[2].value = 2.f;
+                values[3].label = "Bend +/-";
+                values[3].value = 3.f;
+                values[4].label = "Skew +";
+                values[4].value = 4.f;
+                values[5].label = "Skew -";
+                values[5].value = 5.f;
+                values[6].label = "Skew +/-";
+                values[6].value = 6.f;
+            }
             break;
         case paramVerticalWarpAmount:
             parameter.name = "V Warp Amount";

--- a/src/WolfShaperUI.cpp
+++ b/src/WolfShaperUI.cpp
@@ -49,6 +49,7 @@ WolfShaperUI::WolfShaperUI()
     fGraphBar->setStrokeWidth(4.0f * scaleFactor);
 
     fSwitchRemoveDC = new RemoveDCSwitch(this, Size<uint>(30 * scaleFactor, 29 * scaleFactor));
+    fSwitchRemoveDC->setDown(true);
     fSwitchRemoveDC->setCallback(this);
     fSwitchRemoveDC->setId(paramRemoveDC);
 
@@ -74,6 +75,7 @@ WolfShaperUI::WolfShaperUI()
     fKnobPreGain->setRange(0.0f, 2.0f);
     fKnobPreGain->setId(paramPreGain);
     fKnobPreGain->setColor(Color(255, 197, 246, 255));
+    fKnobPreGain->setValue(1.0f, false);
 
     fLabelWet = new LabelBox(this, Size<uint>(knobsLabelBoxWidth, knobsLabelBoxHeight));
     fLabelWet->setText("WET");
@@ -83,6 +85,7 @@ WolfShaperUI::WolfShaperUI()
     fKnobWet->setRange(0.0f, 1.0f);
     fKnobWet->setId(paramWet);
     fKnobWet->setColor(Color(136, 228, 255));
+    fKnobWet->setValue(1.0f, false);
 
     fLabelPostGain = new LabelBox(this, Size<uint>(knobsLabelBoxWidth, knobsLabelBoxHeight));
     fLabelPostGain->setText("POST");
@@ -92,12 +95,14 @@ WolfShaperUI::WolfShaperUI()
     fKnobPostGain->setRange(0.0f, 1.0f);
     fKnobPostGain->setId(paramPostGain);
     fKnobPostGain->setColor(Color(143, 255, 147, 255));
+    fKnobPostGain->setValue(1.0f, false);
 
     fKnobHorizontalWarp = new VolumeKnob(this, Size<uint>(54 * scaleFactor, 54 * scaleFactor));
     fKnobHorizontalWarp->setCallback(this);
     fKnobHorizontalWarp->setRange(0.0f, 1.0f);
     fKnobHorizontalWarp->setId(paramHorizontalWarpAmount);
     fKnobHorizontalWarp->setColor(Color(255, 225, 169, 255));
+    fKnobHorizontalWarp->setValue(0.0f, false);
 
     fLabelListHorizontalWarpType = new LabelBoxList(this, Size<uint>(knobsLabelBoxWidth + 3 * scaleFactor, knobsLabelBoxHeight));
     fLabelListHorizontalWarpType->setLabels({"–", "BEND +", "BEND -", "BEND +/-", "SKEW +", "SKEW -", "SKEW +/-"});
@@ -107,6 +112,7 @@ WolfShaperUI::WolfShaperUI()
     fKnobVerticalWarp->setRange(0.0f, 1.0f);
     fKnobVerticalWarp->setId(paramVerticalWarpAmount);
     fKnobVerticalWarp->setColor(Color(255, 225, 169, 255));
+    fKnobVerticalWarp->setValue(0.f, false);
 
     fLabelListVerticalWarpType = new LabelBoxList(this, Size<uint>(knobsLabelBoxWidth + 3 * scaleFactor, knobsLabelBoxHeight));
     fLabelListVerticalWarpType->setLabels({"–", "BEND +", "BEND -", "BEND +/-", "SKEW +", "SKEW -", "SKEW +/-"});


### PR DESCRIPTION
Changes should be self-explanatory, but to summarize:
- DSP and UI should start with the same state, otherwise UI will show incorrect values
- Enumerations are nice so hosts that use generic UI can show those as the real parameter values instead of just numbers
- The gain controls were set as logarithmic, but no log scale was ever in use in the GUI, removed the hint to make DSP side behave the same as the UI does
